### PR TITLE
Add AI auth test using Jest

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -30,5 +30,9 @@
     "socket.io": "^4.8.1",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/backend/tests/ai.test.js
+++ b/backend/tests/ai.test.js
@@ -1,0 +1,12 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('AI Routes', () => {
+  test('POST /api/ai/ask without JWT returns 401', async () => {
+    const res = await request(app)
+      .post('/api/ai/ask')
+      .send({ question: 'Test question' });
+
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- enable Jest testing in the backend
- add Jest and Supertest as dev dependencies
- create a test that checks `/api/ai/ask` returns 401 without a JWT

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ce1d0099c8332927d9086044b0660